### PR TITLE
Replace previous 'moio' repo name with 'uyuni-project'

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"path/filepath"
 
-	"github.com/moio/minima/get"
+	"github.com/uyuni-project/minima/get"
 	"github.com/spf13/cobra"
 	yaml "gopkg.in/yaml.v2"
 )

--- a/get/filestorage.go
+++ b/get/filestorage.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/moio/minima/util"
+	"github.com/uyuni-project/minima/util"
 )
 
 // FileStorage allows to store data in a local directory

--- a/get/s3storage.go
+++ b/get/s3storage.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-	"github.com/moio/minima/util"
+	"github.com/uyuni-project/minima/util"
 )
 
 // S3Storage allows to store data in an Amazon S3 bucket

--- a/get/storage.go
+++ b/get/storage.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"io"
 
-	"github.com/moio/minima/util"
+	"github.com/uyuni-project/minima/util"
 )
 
 // Location represents a directory in a Storage object

--- a/get/syncer.go
+++ b/get/syncer.go
@@ -14,7 +14,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/moio/minima/util"
+	"github.com/uyuni-project/minima/util"
 	"golang.org/x/crypto/openpgp"
 )
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/moio/minima/cmd"
+import "github.com/uyuni-project/minima/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
Fix missing replacements after moving the project repo under the `uyuni-project` umbrella.