### PR TITLE
GetRepo refactor: parallelize HTTP calls

### DIFF
--- a/cmd/updates.go
+++ b/cmd/updates.go
@@ -247,6 +247,7 @@ func GetRepo(client *http.Client, mu string) (httpFormattedRepos []get.HTTPRepoC
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving products for MU %s: %v", mu, err)
 	}
+	fmt.Printf("%d product entries for mu %s\n", len(productsChunks), mu)
 
 	reposChan := make(chan []get.HTTPRepoConfig)
 	errChan := make(chan error)
@@ -294,6 +295,7 @@ func GetRepo(client *http.Client, mu string) (httpFormattedRepos []get.HTTPRepoC
 }
 
 func getProductsForMU(client *http.Client, mu string) ([]string, error) {
+	fmt.Println("GET", mu)
 	resp, err := client.Get(mu)
 	if err != nil {
 		return nil, err
@@ -303,6 +305,7 @@ func getProductsForMU(client *http.Client, mu string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	chunks := strings.Split(string(body), "\"")
 	productsChunks := cleanWebChunks(chunks)
 
@@ -311,11 +314,12 @@ func getProductsForMU(client *http.Client, mu string) ([]string, error) {
 
 func cleanWebChunks(chunks []string) []string {
 	products := []string{}
-	regEx := regexp.MustCompile(`^SUSE`)
+	regEx := regexp.MustCompile(`>(SUSE[^<]+\/)<`)
 
 	for _, chunk := range chunks {
-		if regEx.FindString(chunk) != "" {
-			products = append(products, chunk)
+		matches := regEx.FindStringSubmatch(chunk)
+		if matches != nil {
+			products = append(products, matches[1])
 		}
 	}
 	return products

--- a/cmd/updates.go
+++ b/cmd/updates.go
@@ -38,7 +38,7 @@ type Updates struct {
 	ReleaseRequest string
 	SRCRPMS        []string
 	Products       string
-	Repositories   []HTTPRepoConfig
+	Repositories   []get.HTTPRepoConfig
 }
 
 // package scoped array of all possible available archs to check for a repo
@@ -170,9 +170,9 @@ func muFindAndSync() {
 	//time.Sleep(60 * time.Second)
 }
 
-func ProcWebChunk(client *http.Client, product, maint string) ([]HTTPRepoConfig, error) {
-	httpFormattedRepos := []HTTPRepoConfig{}
-	repo := HTTPRepoConfig{
+func ProcWebChunk(client *http.Client, product, maint string) ([]get.HTTPRepoConfig, error) {
+	httpFormattedRepos := []get.HTTPRepoConfig{}
+	repo := get.HTTPRepoConfig{
 		Archs: []string{},
 	}
 	repoUrl := maint + product
@@ -198,7 +198,7 @@ func ProcWebChunk(client *http.Client, product, maint string) ([]HTTPRepoConfig,
 }
 
 // ---- This function checks that all architecture slice of a *HTTPRepoConfig is filled right
-func ArchMage(client *http.Client, repo *HTTPRepoConfig) error {
+func ArchMage(client *http.Client, repo *get.HTTPRepoConfig) error {
 	archsChan := make(chan string)
 	// we need a dedicated goroutine to start the others, wait for them to finish
 	// and signal back that we're done doing HTTP calls
@@ -242,13 +242,13 @@ func ArchMage(client *http.Client, repo *HTTPRepoConfig) error {
 	return nil
 }
 
-func GetRepo(client *http.Client, mu string) (httpFormattedRepos []HTTPRepoConfig, err error) {
+func GetRepo(client *http.Client, mu string) (httpFormattedRepos []get.HTTPRepoConfig, err error) {
 	productsChunks, err := getProductsForMU(client, mu)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving products for MU %s: %v", mu, err)
 	}
 
-	reposChan := make(chan []HTTPRepoConfig)
+	reposChan := make(chan []get.HTTPRepoConfig)
 	errChan := make(chan error)
 	// empty struct for 0 allocation: we need only to signal we're done, not pass data
 	doneChan := make(chan struct{})

--- a/cmd/updates.go
+++ b/cmd/updates.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+Copyright © 2021-2024 NAME HERE <EMAIL ADDRESS>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/updates_test.go
+++ b/cmd/updates_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/uyuni-project/minima/get"
 )
 
 var sle15sp4Entry = "SUSE_SLE-15-SP4_Update/"
@@ -101,7 +102,7 @@ func TestArchMage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			repo := HTTPRepoConfig{
+			repo := get.HTTPRepoConfig{
 				URL:   maint + sle15sp4Entry + tt.urlArch,
 				Archs: []string{},
 			}
@@ -120,14 +121,14 @@ func TestProcWebChunk(t *testing.T) {
 		maint      string
 		product    string
 		validArchs []string
-		want       []HTTPRepoConfig
+		want       []get.HTTPRepoConfig
 		netWorkErr bool
 		wantErr    bool
 	}{
 		{
 			"Valid maint repo - single valid arch", "http://download.suse.de/ibs/SUSE:/Maintenance:/2/", "SUSE_SLE-15-SP4_Update/",
 			[]string{"aarch64"},
-			[]HTTPRepoConfig{
+			[]get.HTTPRepoConfig{
 				{
 					URL:   "http://download.suse.de/ibs/SUSE:/Maintenance:/2/SUSE_SLE-15-SP4_Update/",
 					Archs: []string{"aarch64"},
@@ -139,7 +140,7 @@ func TestProcWebChunk(t *testing.T) {
 		{
 			"Valid maint repo - multiple valid archs", "http://download.suse.de/ibs/SUSE:/Maintenance:/3/", "SUSE_SLE-15-SP4_Update/",
 			[]string{"x86_64", "aarch64", "ppc64le", "s390x"},
-			[]HTTPRepoConfig{
+			[]get.HTTPRepoConfig{
 				{
 					URL:   "http://download.suse.de/ibs/SUSE:/Maintenance:/3/SUSE_SLE-15-SP4_Update/",
 					Archs: []string{"x86_64", "aarch64", "ppc64le", "s390x"},
@@ -151,14 +152,14 @@ func TestProcWebChunk(t *testing.T) {
 		{
 			"Valid maint repo - no valid archs", "http://download.suse.de/ibs/SUSE:/Maintenance:/4/", "SUSE_SLE-15-SP4_Update/",
 			[]string{},
-			[]HTTPRepoConfig{},
+			[]get.HTTPRepoConfig{},
 			false,
 			true,
 		},
 		{
 			"Network error", "http://download.suse.de/ibs/SUSE:/Maintenance:/5/", "SUSE_SLE-15-SP4_Update/",
 			[]string{},
-			[]HTTPRepoConfig{},
+			[]get.HTTPRepoConfig{},
 			true,
 			true,
 		},
@@ -216,14 +217,14 @@ func TestGetRepo(t *testing.T) {
 		name       string
 		mu         string
 		validArchs []string
-		want       []HTTPRepoConfig
+		want       []get.HTTPRepoConfig
 		netWorkErr bool
 		wantErr    bool
 	}{
 		{
 			"Single arch", "http://download.suse.de/ibs/SUSE:/Maintenance:/8/",
 			[]string{"x86_64"},
-			[]HTTPRepoConfig{
+			[]get.HTTPRepoConfig{
 				{
 					URL:   "http://download.suse.de/ibs/SUSE:/Maintenance:/8/SUSE_SLE-15-SP4_Update/",
 					Archs: []string{"x86_64"},
@@ -239,7 +240,7 @@ func TestGetRepo(t *testing.T) {
 		{
 			"Multiple archs", "http://download.suse.de/ibs/SUSE:/Maintenance:/9/",
 			[]string{"x86_64", "aarch64", "ppc64le", "s390x"},
-			[]HTTPRepoConfig{
+			[]get.HTTPRepoConfig{
 				{
 					URL:   "http://download.suse.de/ibs/SUSE:/Maintenance:/9/SUSE_SLE-15-SP4_Update/",
 					Archs: []string{"x86_64", "aarch64", "ppc64le", "s390x"},
@@ -255,14 +256,14 @@ func TestGetRepo(t *testing.T) {
 		{
 			"No available archs", "http://download.suse.de/ibs/SUSE:/Maintenance:/10/",
 			[]string{},
-			[]HTTPRepoConfig{},
+			[]get.HTTPRepoConfig{},
 			false,
 			true,
 		},
 		{
 			"Network error", "http://download.suse.de/ibs/SUSE:/Maintenance:/11/",
 			[]string{},
-			[]HTTPRepoConfig{},
+			[]get.HTTPRepoConfig{},
 			true,
 			true,
 		},

--- a/cmd/updates_test.go
+++ b/cmd/updates_test.go
@@ -57,7 +57,9 @@ func createMockClient(baseUrl string, archs []string, forceError bool) *http.Cli
 	responses[baseUrl] = &http.Response{
 		Status:     "200 OK",
 		StatusCode: 200,
-		Body:       io.NopCloser(bytes.NewBufferString("\"SUSE_SLE-15-SP4_Update/\"\"SLE-15SP5_Update/\"\"SUSE_SLE-15-SP6_Update/\"")),
+		Body: io.NopCloser(bytes.NewBufferString(`<a href=\"/ibs/SUSE:/Maintenance:/number/SUSE_SLE-15-SP4_Update/\">SUSE_SLE-15-SP4_Update/</a>
+		<a href=\"/ibs/SUSE:/Maintenance:/number/SLE-15-SP4_Update/\">SLE-15-SP5_Update/</a>
+		<a href=\"/ibs/SUSE:/Maintenance:/number/SUSE_SLE-15-SP4_Update/\">SUSE_SLE-15-SP6_Update/</a>`)),
 	}
 
 	for _, p := range productEntries {

--- a/cmd/updates_test.go
+++ b/cmd/updates_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+Copyright © 2021-2024 NAME HERE <EMAIL ADDRESS>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/updates_test.go
+++ b/cmd/updates_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockTransport struct {
+	responses map[string]*http.Response
+}
+
+func (mrt *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if res, ok := mrt.responses[req.URL.String()]; ok {
+		return res, nil
+	}
+
+	return &http.Response{
+		Status:     "404 Not Found",
+		StatusCode: 404,
+		Body:       io.NopCloser(bytes.NewBufferString("")),
+	}, nil
+}
+
+func createMockClient(baseUrl string, archs []string) *http.Client {
+	responses := make(map[string]*http.Response, len(archs))
+
+	for _, arch := range archs {
+		url := fmt.Sprintf("%s%s/", baseUrl, arch)
+		responses[url] = &http.Response{
+			Status:     "200 OK",
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewBufferString("")),
+		}
+	}
+
+	return &http.Client{
+		Transport: &mockTransport{responses: responses},
+	}
+}
+
+func TestArchMage(t *testing.T) {
+	baseUrl := "http://download.suse.de/ibs/totallyrandomtestrepo/"
+
+	tests := []struct {
+		name       string
+		url        string
+		validArchs []string
+		wantErr    bool
+	}{
+		{"Arch in repo URL", baseUrl + "x86_64/", []string{"x86_64"}, false},
+		{"Single available arch for a repo", baseUrl, []string{"aarch64"}, false},
+		{"Multiple available archs for a repo", baseUrl, []string{"x86_64", "aarch64", "ppc64le", "s390x"}, false},
+		{"No available archs for a repo", baseUrl, []string{}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := HTTPRepoConfig{
+				URL:   tt.url,
+				Archs: []string{},
+			}
+			mockClient := createMockClient(repo.URL, tt.validArchs)
+
+			err := ArchMage(mockClient, &repo)
+			assert.EqualValues(t, tt.wantErr, (err != nil))
+
+			for arch := range tt.validArchs {
+				var found bool
+				for repoArch := range repo.Archs {
+					if arch == repoArch {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found)
+			}
+		})
+	}
+}

--- a/updates/obs.go
+++ b/updates/obs.go
@@ -67,7 +67,7 @@ func (c *Client) GetPatchinfo(rr ReleaseRequest) (*Patchinfo, error) {
 }
 
 func (c *Client) do(req *http.Request, v interface{}) (*http.Response, error) {
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.HttpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func NewClient(username string, password string) *Client {
 		BaseURL:    &url.URL{Host: baseUrl, Scheme: "https"},
 		Username:   username,
 		Password:   password,
-		httpClient: &http.Client{},
+		HttpClient: &http.Client{},
 	}
 }
 

--- a/updates/obs.go
+++ b/updates/obs.go
@@ -4,7 +4,6 @@ package updates
 import (
 	"bytes"
 	"encoding/xml"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -73,7 +72,7 @@ func (c *Client) do(req *http.Request, v interface{}) (*http.Response, error) {
 		return nil, err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, errors.New(fmt.Sprintf("Got status code: %v for %q\n", resp.StatusCode, req.URL))
+		return nil, fmt.Errorf("got status code: %v for %q", resp.StatusCode, req.URL)
 	}
 	defer resp.Body.Close()
 	err = xml.NewDecoder(resp.Body).Decode(v)
@@ -89,14 +88,11 @@ func NewClient(username string, password string) *Client {
 	}
 }
 
-func CheckWebPageExists(repoURL string) (bool, error) {
-	client := &http.Client{}
+func CheckWebPageExists(client *http.Client, repoURL string) (bool, error) {
 	resp, err := client.Head(repoURL)
 	if err != nil {
 		return false, err
 	}
-	if resp.Status == "200 OK" {
-		return true, nil
-	}
-	return false, nil
+
+	return resp.Status == "200 OK", nil
 }

--- a/updates/obs_data.go
+++ b/updates/obs_data.go
@@ -7,16 +7,14 @@ import (
 
 const (
 	DownloadIbsLink = "http://download.suse.de/ibs/SUSE:/Maintenance:/"
-	baseUrl = "api.suse.de"
+	baseUrl         = "api.suse.de"
 )
-
-
 
 type Client struct {
 	BaseURL    *url.URL
 	Username   string
 	Password   string
-	httpClient *http.Client
+	HttpClient *http.Client
 }
 
 type Person struct {


### PR DESCRIPTION
Refactors the `GetRepo`, `ProcWebChunk` and `ArchMage` functions.

The aim is:

1) to improve channels and goroutines usage, in order to execute HTTP calls in parallel. Previous code was using channels in a way that would still result in the calls being executed sequentially ( I can further elaborate on this if needed).

2) avoid re-instantiating a HTTP client and have some functions accept one as an argument. This makes the code more testable (via mock HTTP clients) and avoids wasting resources, as the std HTTP client is already thread safe.

3) use a package scoped sync.Map (thread safe Map) as cache to avoid unnecessary HTTP calls and move the architectures slice to a package scoped variable (there's no need to re-instantiate it over and over).

4) Cleaning up the web chunks and calling ProcWebchunk only for the ones representing a SUSE product. This avoids unnecessary function calls. The RegEx used to identify product entries has also been made more robust.

5) use `*HTTPRepoConfig `as argument for `ArchMage` as the function really felt like it was written to work with a pointer. The function doc comment even stated that despite having a copy being passed to it. 
Overall, this is just a secondary, minor, improvement though.

6) add some test coverage

7) gofmt formatting here and there