### PR TITLE
Allow different SCC subsections

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ http:
 # scc:
 #   username: UC7
 #   password: INSERT_PASSWORD_HERE
-#   repo_names:
-#     - SLES12-SP2-LTSS-Updates
-#   archs: [x86_64]
+#   repositories:
+#     - names:
+#       - SLES12-SP2-LTSS-Updates
+#       archs: [x86_64]
 
 # OBS credentials:
 # obs:

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -76,7 +76,7 @@ var (
 	syncLegacyPackages bool
 )
 
-// Config maps the configuraiton in minima.yaml
+// Config maps the configuration in minima.yaml
 type Config struct {
 	Storage get.StorageConfig
 	SCC     get.SCC
@@ -147,7 +147,7 @@ func parseConfig(configString string) (Config, error) {
 	}
 
 	storageType := config.Storage.Type
-	if storageType != "file" && storageType != "s3" && storageType != "gcp" {
+	if storageType != "file" && storageType != "s3" {
 		return config, fmt.Errorf("configuration parse error: unrecognised storage type")
 	}
 	return config, nil

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -45,9 +45,11 @@ var (
     # scc:
     #   username: UC7
     #   password: INSERT_PASSWORD_HERE
-    #   repo_names:
-    #     - SLES12-SP2-LTSS-Updates
-    #   archs: [x86_64]
+    #   repositories:
+	#     - names:
+    #       - SLE-Product-SLES15-SP5-Pool
+	#       - SLE-Product-SLES15-SP5-Updates
+    #       archs: [x86_64]
   `,
 		Run: func(cmd *cobra.Command, args []string) {
 			var errorflag bool = false

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uyuni-project/minima/get"
+)
+
+const (
+	testdataDir        = "testdata"
+	invalidStoragefile = "invalid_storage.yaml"
+	validHTTPReposFile = "valid_http_repos.yaml"
+	validSCCReposFile  = "valid_scc_repos.yaml"
+)
+
+func TestParseConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputFile string
+		want      Config
+		wantErr   bool
+	}{
+		{
+			"Valid HTTP repos", validHTTPReposFile,
+			Config{
+				Storage: get.StorageConfig{
+					Type: "file",
+					Path: "/srv/mirror",
+				},
+				HTTP: []get.HTTPRepoConfig{
+					{
+						URL:   "http://test/SLE-Product-SLES15-SP5-Pool/",
+						Archs: []string{"x86_64", "aarch64", "s390x"},
+					},
+					{
+						URL:   "http://test/SLE-Product-SLES15-SP5-Updates/",
+						Archs: []string{"x86_64", "aarch64"},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"Valid SCC repos", validSCCReposFile,
+			Config{
+				Storage: get.StorageConfig{
+					Type: "file",
+					Path: "/srv/mirror",
+				},
+				SCC: get.SCC{
+					Username: "user",
+					Password: "pass",
+					Repositories: []get.SCCReposConfig{
+						{
+							Names: []string{"SLE-Manager-Tools15-Pool", "SLE-Manager-Tools15-Updates"},
+							Archs: []string{"x86_64", "aarch64", "s390x"},
+						},
+						{
+							Names: []string{"SLE-Product-SLES15-SP5-Pool", "SLE-Product-SLES15-SP5-Updates"},
+							Archs: []string{"x86_64", "s390x"},
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"Invalid storage", invalidStoragefile,
+			Config{
+				Storage: get.StorageConfig{
+					Type: "memory",
+					Path: "/srv/mirror",
+				},
+				HTTP: []get.HTTPRepoConfig{
+					{
+						URL:   "http://test/SLE-Product-SLES15-SP5-Pool/",
+						Archs: []string{"x86_64", "aarch64", "s390x"},
+					},
+					{
+						URL:   "http://test/SLE-Product-SLES15-SP5-Updates/",
+						Archs: []string{"x86_64", "aarch64"},
+					},
+				},
+			},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath := path.Join(testdataDir, tt.inputFile)
+			bytes, err := os.ReadFile(filePath)
+			if err != nil {
+				t.Fatal()
+			}
+			configString := string(bytes)
+
+			got, err := parseConfig(configString)
+			assert.EqualValues(t, tt.wantErr, (err != nil))
+			if !assert.ObjectsAreEqualValues(tt.want, got) {
+				t.Errorf("Expected %v - got %v", tt.want, got)
+			}
+		})
+	}
+}

--- a/cmd/testdata/invalid_storage.yaml
+++ b/cmd/testdata/invalid_storage.yaml
@@ -1,0 +1,9 @@
+storage:
+  type: memory
+  path: /srv/mirror
+
+http:
+  - url: http://test/SLE-Product-SLES15-SP5-Pool/
+    archs: [x86_64, aarch64, s390x]
+  - url: http://test/SLE-Product-SLES15-SP5-Updates/
+    archs: [x86_64, aarch64]

--- a/cmd/testdata/valid_http_repos.yaml
+++ b/cmd/testdata/valid_http_repos.yaml
@@ -1,0 +1,9 @@
+storage:
+  type: file
+  path: /srv/mirror
+
+http:
+  - url: http://test/SLE-Product-SLES15-SP5-Pool/
+    archs: [x86_64, aarch64, s390x]
+  - url: http://test/SLE-Product-SLES15-SP5-Updates/
+    archs: [x86_64, aarch64]

--- a/cmd/testdata/valid_scc_repos.yaml
+++ b/cmd/testdata/valid_scc_repos.yaml
@@ -1,0 +1,16 @@
+storage:
+  type: file
+  path: /srv/mirror
+
+scc:
+  username: user
+  password: pass
+  repositories:
+    - names:
+      - SLE-Manager-Tools15-Pool
+      - SLE-Manager-Tools15-Updates
+      archs: [x86_64, aarch64, s390x]
+    - names:
+      - SLE-Product-SLES15-SP5-Pool
+      - SLE-Product-SLES15-SP5-Updates
+      archs: [x86_64, s390x]

--- a/get/scc.go
+++ b/get/scc.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 )
 
+// SCC defines the configuration to be used for downloading packages from SUSE Customer Center
 type SCC struct {
 	Username     string
 	Password     string
@@ -28,6 +29,7 @@ type HTTPRepoConfig struct {
 	Archs []string
 }
 
+// Repo represents the JSON entry for a repository as retuned by SCC API
 type Repo struct {
 	URL          string
 	Name         string

--- a/get/scc.go
+++ b/get/scc.go
@@ -10,6 +10,12 @@ import (
 	"strings"
 )
 
+type SCC struct {
+	Username     string
+	Password     string
+	Repositories []SCCReposConfig
+}
+
 // SCCRepoConfig defines the configuration of SCC repos sharing the same architectures
 type SCCReposConfig struct {
 	Names []string

--- a/get/scc_test.go
+++ b/get/scc_test.go
@@ -1,33 +1,111 @@
 package get
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestSCCURLs(t *testing.T) {
-	// Respond to http://localhost:8080/test with "Hello, World"
+func TestSCCToHTTPConfigs(t *testing.T) {
+	expectedToken := base64.URLEncoding.EncodeToString([]byte("user:pass"))
+	expectedAuth := "Basic " + expectedToken
+
 	http.HandleFunc("/connect/organizations/repositories", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != expectedAuth {
+			w.WriteHeader(401)
+			return
+		}
+
 		w.Header().Set("Link", "<http://localhost:8080/connect/organizations/repositories2>; rel=\"next\"")
-		fmt.Fprintf(w, "[{\"url\" : \"test\", \"name\" : \"test\", \"description\" : \"test\"}]")
+		fmt.Fprintf(w, "[{\"url\" : \"http://whatever/SLES15-SP5-Pool\", \"name\" : \"SLES15-SP5-Pool\", \"description\" : \"x86_64 aarch64 i586\"}]")
 	})
 
 	http.HandleFunc("/connect/organizations/repositories2", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Link", "")
-		fmt.Fprintf(w, "[{\"url\" : \"test2\", \"name\" : \"test2\", \"description\" : \"test2\"}]")
+		fmt.Fprintf(w, "[{\"url\" : \"http://whatever/SLES15-SP5-Updates\", \"name\" : \"SLES15-SP5-Updates\", \"description\" : \"x86_64 aarch64 s390x ppc64le\"}]")
 	})
 
-	urls, err := SCCURLs("http://localhost:8080", "user", "pass", []string{"test2"}, []string{""})
-	if err != nil {
-		t.Error(err)
+	tests := []struct {
+		name    string
+		user    string
+		pass    string
+		names   []string
+		archs   []string
+		want    []HTTPRepoConfig
+		wantErr bool
+	}{
+		{
+			"One name and no matching arch", "user", "pass",
+			[]string{"SLES15-SP5-Pool"}, []string{"s390x"},
+			[]HTTPRepoConfig{},
+			false,
+		},
+		{
+			"One name and one matching arch", "user", "pass",
+			[]string{"SLES15-SP5-Pool"}, []string{"x86_64"},
+			[]HTTPRepoConfig{
+				{URL: "http://whatever/SLES15-SP5-Pool", Archs: []string{"x86_64"}},
+			},
+			false,
+		},
+		{
+			"One name and multiple matching archs", "user", "pass",
+			[]string{"SLES15-SP5-Pool"}, []string{"aarch64", "i586"},
+			[]HTTPRepoConfig{
+				{URL: "http://whatever/SLES15-SP5-Pool", Archs: []string{"aarch64", "i586"}},
+			},
+			false,
+		},
+		{
+			"Multiple names and no matching archs", "user", "pass",
+			[]string{"SLES15-SP5-Pool", "SLES15-SP5-Updates"}, []string{"src"},
+			[]HTTPRepoConfig{},
+			false,
+		},
+		{
+			"Multiple names and multiple matching archs", "user", "pass",
+			[]string{"SLES15-SP5-Pool", "SLES15-SP5-Updates"}, []string{"x86_64", "aarch64"},
+			[]HTTPRepoConfig{
+				{URL: "http://whatever/SLES15-SP5-Pool", Archs: []string{"x86_64", "aarch64"}},
+				{URL: "http://whatever/SLES15-SP5-Updates", Archs: []string{"x86_64", "aarch64"}},
+			},
+			false,
+		},
+		{
+			"Invalid user", "thiswillfail", "pass",
+			[]string{"SLES15-SP5-Pool"}, []string{"x86_64"},
+			[]HTTPRepoConfig{},
+			true,
+		},
+		{
+			"Invalid password", "user", "thiswillfail",
+			[]string{"SLES15-SP5-Pool"}, []string{"x86_64"},
+			[]HTTPRepoConfig{},
+			true,
+		},
 	}
 
-	if len(urls) != 1 {
-		t.Error("expected 1 url")
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			httpConfigs, err := SCCToHTTPConfigs("http://localhost:8080", tt.user, tt.pass, []SCCReposConfig{
+				{
+					Names: tt.names,
+					Archs: tt.archs,
+				},
+			})
+			assert.EqualValues(t, tt.wantErr, (err != nil))
+			assert.Equal(t, len(tt.want), len(httpConfigs))
 
-	if urls[0] != "test2" {
-		t.Error("expected test2, got " + urls[0])
+			for i := range httpConfigs {
+				wantConfig := tt.want[i]
+				gotConfig := httpConfigs[i]
+
+				assert.EqualValues(t, wantConfig.URL, gotConfig.URL)
+				assert.ElementsMatch(t, wantConfig.Archs, gotConfig.Archs)
+			}
+		})
 	}
 }

--- a/get/storage.go
+++ b/get/storage.go
@@ -18,6 +18,19 @@ const (
 	Temporary
 )
 
+type StorageConfig struct {
+	Type string
+	// file-specific
+	Path string
+	// s3-specific
+	AccessKeyID     string `yaml:"access_key_id"`
+	SecretAccessKey string `yaml:"secret_access_key"`
+	Region          string
+	Bucket          string
+	JsonPath        string `yaml:"jsonpath"`
+	ProjectID       string `yaml:"projectid"`
+}
+
 // Storage allows to store data in the form of files. Files are accumulated in
 // a "temporary" location until Commit is called at that point any file in the
 // temporary location is moved in the "permanent" location

--- a/updates/obs.go
+++ b/updates/obs.go
@@ -11,6 +11,11 @@ import (
 	"net/url"
 )
 
+type OBS struct {
+	Username string
+	Password string
+}
+
 func (c *Client) NewRequest(method, path string, body interface{}) (*http.Request, error) {
 	rel := &url.URL{Path: path}
 	u := c.BaseURL.ResolveReference(rel)
@@ -85,13 +90,13 @@ func NewClient(username string, password string) *Client {
 }
 
 func CheckWebPageExists(repoURL string) (bool, error) {
- 	client := &http.Client{}
+	client := &http.Client{}
 	resp, err := client.Head(repoURL)
 	if err != nil {
 		return false, err
 	}
 	if resp.Status == "200 OK" {
-		return true, nil 
+		return true, nil
 	}
-		return false, nil
+	return false, nil
 }


### PR DESCRIPTION
Related to https://github.com/SUSE/spacewalk/issues/25285

closes https://github.com/uyuni-project/minima/issues/26

This PR refactors and expands the existing code in order to allow defining multiple subsection for SCC in YAML files.
It should now be possible to define files such as:

```yaml
# Define here SCC products for all architectures

storage:
  type: file
  path: /srv/mirror

scc:
  username: {{ salt['pillar.get']('scc:org_user', '') }}
  password: {{ salt['pillar.get']('scc:org_pass', '') }}
  repositories:
    # SUSE Manager Tools
    - names:
      - SLE-Manager-Tools15-Pool
      - SLE-Manager-Tools15-Updates
      archs: [x86_64, aarch64, s390x]
    - names:
       # SLES 15-SP5 Products
      - SLE-Product-SLES15-SP5-Pool
      - SLE-Product-SLES15-SP5-Updates
      # SLE 15-SP5 Basic modules
      - SLE-Module-Basesystem15-SP5-Pool
      - SLE-Module-Basesystem15-SP5-Updates
      - SLE-Module-Server-Applications15-SP5-Pool
      - SLE-Module-Server-Applications15-SP5-Updates
      # SLES 15-SP6 Products
      - SLE-Product-SLES15-SP6-Pool
      - SLE-Product-SLES15-SP6-Updates
      # SLE 15-SP6 Basic modules
      - SLE-Module-Basesystem15-SP6-Pool
      - SLE-Module-Basesystem15-SP6-Updates
      - SLE-Module-Python3-15-SP6-Pool
      - SLE-Module-Python3-15-SP6-Updates
      - SLE-Module-Server-Applications15-SP6-Pool
      - SLE-Module-Server-Applications15-SP6-Updates
       archs: [x86_64, s390x]

  .....
```

Other possible improvements:

- [ ] Add a username and password for each subsection. Doable but will likely require to add a username and password flag to the CLI.

- [ ] Try to parallelize some work. Not sure it'll be worth the effort, but processing each SCC subsection in parallel shouldn't require much code/refactors.