### PR TITLE
Set local flags for each command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,7 @@ var RootCmd = &cobra.Command{
 			os.Exit(0)
 		}
 
-		initConfig()
+		cmd.Help()
 	},
 }
 
@@ -41,8 +41,10 @@ func Execute(versionTag string) {
 }
 
 func init() {
-	RootCmd.Flags().BoolP("version", "v", false, "Print minima version")
+	// all sub-commands will have access to this flag
 	RootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "minima.yaml", "config file")
+	// local flags
+	RootCmd.Flags().BoolP("version", "v", false, "Print minima version")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -52,6 +52,8 @@ var (
     #       archs: [x86_64]
   `,
 		Run: func(cmd *cobra.Command, args []string) {
+			initConfig()
+
 			var errorflag bool = false
 			syncers, err := syncersFromConfig(cfgString)
 			if err != nil {
@@ -157,7 +159,8 @@ func parseConfig(configString string) (Config, error) {
 
 func init() {
 	RootCmd.AddCommand(syncCmd)
-	RootCmd.PersistentFlags().StringVarP(&thisRepo, "repository", "r", "", "flag that can specifies a single repo (example: SLES11-SP4-Updates)")
-	RootCmd.PersistentFlags().StringVarP(&archs, "arch", "a", "", "flag that specifies covered archs in the given repo")
-	RootCmd.PersistentFlags().BoolVarP(&syncLegacyPackages, "legacypackages", "l", false, "flag that triggers mirroring of i586 pkgs in x86_64 repos")
+	// local flags
+	syncCmd.Flags().StringVarP(&thisRepo, "repository", "r", "", "flag that can specifies a single repo (example: SLES11-SP4-Updates)")
+	syncCmd.Flags().StringVarP(&archs, "arch", "a", "", "flag that specifies covered archs in the given repo")
+	syncCmd.Flags().BoolVarP(&syncLegacyPackages, "legacypackages", "l", false, "flag that triggers mirroring of i586 pkgs in x86_64 repos")
 }

--- a/cmd/updates.go
+++ b/cmd/updates.go
@@ -36,7 +36,7 @@ import (
 
 // mufnsCmd represents the mufns command
 var (
-	update = &cobra.Command{
+	updateCmd = &cobra.Command{
 		Use:   "updates",
 		Short: "searches all updates and syncs them to mirror",
 		Long: `A longer description that spans multiple lines and likely contains examples
@@ -46,6 +46,7 @@ Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 		Run: func(cmd *cobra.Command, args []string) {
+			initConfig()
 			muFindAndSync()
 		},
 	}
@@ -56,11 +57,12 @@ to quickly create a Cobra application.`,
 )
 
 func init() {
-	RootCmd.AddCommand(update)
-	RootCmd.PersistentFlags().BoolVarP(&spitYamls, "yaml", "y", false, "flag that would trigger generating minima_obs_<Date>.yaml configs")
-	RootCmd.PersistentFlags().BoolVarP(&justSearch, "search", "s", false, "flag that would trigger only looking for updates on OBS")
-	RootCmd.PersistentFlags().StringVarP(&thisMU, "maintupdate", "m", "", "flag that consumes the name of an MU, like 'SUSE:Maintenance:Incident:ReleaseRequest'")
-	RootCmd.PersistentFlags().BoolVarP(&cleanup, "cleanup", "k", false, "flag that triggers cleaning up the storage (from old MU channels)")
+	RootCmd.AddCommand(updateCmd)
+	// local flags
+	updateCmd.Flags().BoolVarP(&spitYamls, "yaml", "y", false, "flag that would trigger generating minima_obs_<Date>.yaml configs")
+	updateCmd.Flags().BoolVarP(&justSearch, "search", "s", false, "flag that would trigger only looking for updates on OBS")
+	updateCmd.Flags().StringVarP(&thisMU, "maintupdate", "m", "", "flag that consumes the name of an MU, like 'SUSE:Maintenance:Incident:ReleaseRequest'")
+	updateCmd.Flags().BoolVarP(&cleanup, "cleanup", "k", false, "flag that triggers cleaning up the storage (from old MU channels)")
 }
 
 func muFindAndSync() {


### PR DESCRIPTION
Related to https://github.com/SUSE/spacewalk/issues/25285

All flags were being set as global flags belonging to the RootCmd, resulting in help messages displaying all flags even though they were not actually in use by the specific command.

This PR addresses the issue by defining flags that are only meaningful for a command VS global (parent inherited) flags.

The parsing of the configuration .yaml file is also postponed to the actual moment it is needed by the sub-commands.