### PR TITLE
Sync all repo packages by default, use a flag to skip legacy ones

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -77,7 +77,7 @@ var (
 	}
 	thisRepo           string
 	archs              string
-	syncLegacyPackages bool
+	skipLegacyPackages bool
 )
 
 // Config maps the configuration in minima.yaml
@@ -93,8 +93,8 @@ func syncersFromConfig(configString string) ([]*get.Syncer, error) {
 	if err != nil {
 		return nil, err
 	}
-	//---passing the flag value to a global variable in get package, to trigger syncing of i586 rpms inside x86_64
-	get.Legacy = syncLegacyPackages
+	//---passing the flag value to a global variable in get package, to disables syncing of i586 and i686 rpms (usually inside x86_64)
+	get.SkipLegacy = skipLegacyPackages
 
 	if config.SCC.Username != "" {
 		if thisRepo != "" {
@@ -123,11 +123,6 @@ func syncersFromConfig(configString string) ([]*get.Syncer, error) {
 			return nil, err
 		}
 
-		archs := map[string]bool{}
-		for _, archString := range httpRepo.Archs {
-			archs[archString] = true
-		}
-
 		var storage get.Storage
 		switch config.Storage.Type {
 		case "file":
@@ -138,7 +133,7 @@ func syncersFromConfig(configString string) ([]*get.Syncer, error) {
 				return nil, err
 			}
 		}
-		syncers = append(syncers, get.NewSyncer(*repoURL, archs, storage))
+		syncers = append(syncers, get.NewSyncer(*repoURL, storage))
 	}
 
 	return syncers, nil
@@ -162,5 +157,5 @@ func init() {
 	// local flags
 	syncCmd.Flags().StringVarP(&thisRepo, "repository", "r", "", "flag that can specifies a single repo (example: SLES11-SP4-Updates)")
 	syncCmd.Flags().StringVarP(&archs, "arch", "a", "", "flag that specifies covered archs in the given repo")
-	syncCmd.Flags().BoolVarP(&syncLegacyPackages, "legacypackages", "l", false, "flag that triggers mirroring of i586 pkgs in x86_64 repos")
+	syncCmd.Flags().BoolVarP(&skipLegacyPackages, "nolegacy", "l", false, "flag that disables mirroring of i586 and i686 pkgs")
 }

--- a/get/syncer_test.go
+++ b/get/syncer_test.go
@@ -18,15 +18,12 @@ func TestStoreRepo(t *testing.T) {
 		t.Error(err)
 	}
 
-	archs := map[string]bool{
-		"x86_64": true,
-	}
 	storage := NewFileStorage(directory)
 	url, err := url.Parse("http://localhost:8080/repo")
 	if err != nil {
 		t.Error(err)
 	}
-	syncer := NewSyncer(*url, archs, storage)
+	syncer := NewSyncer(*url, storage)
 
 	// first sync
 	err = syncer.StoreRepo()
@@ -75,15 +72,12 @@ func TestStoreRepoZstd(t *testing.T) {
 		t.Error(err)
 	}
 
-	archs := map[string]bool{
-		"x86_64": true,
-	}
 	storage := NewFileStorage(directory)
 	url, err := url.Parse("http://localhost:8080/zstrepo")
 	if err != nil {
 		t.Error(err)
 	}
-	syncer := NewSyncer(*url, archs, storage)
+	syncer := NewSyncer(*url, storage)
 
 	// first sync
 	err = syncer.StoreRepo()
@@ -131,15 +125,12 @@ func TestStoreDebRepo(t *testing.T) {
 		t.Error(err)
 	}
 
-	archs := map[string]bool{
-		"amd64": true,
-	}
 	storage := NewFileStorage(directory)
 	url, err := url.Parse("http://localhost:8080/deb_repo")
 	if err != nil {
 		t.Error(err)
 	}
-	syncer := NewSyncer(*url, archs, storage)
+	syncer := NewSyncer(*url, storage)
 
 	// first sync
 	err = syncer.StoreRepo()


### PR DESCRIPTION
This PR simplifies the checks we do to determine whether we should consider downloading a package found in a repository.

Right now, we apply a quite convoluted mix of checks. Some of them seems to contain typos as well.
We also have a specific flag to signal that we want to download i586 and i686 pkgs present in x86_64 repos.
It seems odd trying to filter packages by arch at that point because when we have access to a repo's metadata it means that we already know the arch of packages it is going to contain.

The PR defines a new default behavior: download all packages found in the repo's metadata.
It also revert the meaning of the flag, to make so that it signal we do NOT want to sync i586 and i686 packages.