### PR TITLE
Filter packages in multi-architecture repositories

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -123,6 +123,11 @@ func syncersFromConfig(configString string) ([]*get.Syncer, error) {
 			return nil, err
 		}
 
+		archs := map[string]bool{}
+		for _, archString := range httpRepo.Archs {
+			archs[archString] = true
+		}
+
 		var storage get.Storage
 		switch config.Storage.Type {
 		case "file":
@@ -133,7 +138,7 @@ func syncersFromConfig(configString string) ([]*get.Syncer, error) {
 				return nil, err
 			}
 		}
-		syncers = append(syncers, get.NewSyncer(*repoURL, storage))
+		syncers = append(syncers, get.NewSyncer(*repoURL, archs, storage))
 	}
 
 	return syncers, nil

--- a/get/syncer_test.go
+++ b/get/syncer_test.go
@@ -18,12 +18,15 @@ func TestStoreRepo(t *testing.T) {
 		t.Error(err)
 	}
 
+	archs := map[string]bool{
+		"x86_64": true,
+	}
 	storage := NewFileStorage(directory)
 	url, err := url.Parse("http://localhost:8080/repo")
 	if err != nil {
 		t.Error(err)
 	}
-	syncer := NewSyncer(*url, storage)
+	syncer := NewSyncer(*url, archs, storage)
 
 	// first sync
 	err = syncer.StoreRepo()
@@ -72,12 +75,15 @@ func TestStoreRepoZstd(t *testing.T) {
 		t.Error(err)
 	}
 
+	archs := map[string]bool{
+		"x86_64": true,
+	}
 	storage := NewFileStorage(directory)
 	url, err := url.Parse("http://localhost:8080/zstrepo")
 	if err != nil {
 		t.Error(err)
 	}
-	syncer := NewSyncer(*url, storage)
+	syncer := NewSyncer(*url, archs, storage)
 
 	// first sync
 	err = syncer.StoreRepo()
@@ -125,12 +131,16 @@ func TestStoreDebRepo(t *testing.T) {
 		t.Error(err)
 	}
 
+	archs := map[string]bool{
+		"amd64": true,
+	}
+
 	storage := NewFileStorage(directory)
 	url, err := url.Parse("http://localhost:8080/deb_repo")
 	if err != nil {
 		t.Error(err)
 	}
-	syncer := NewSyncer(*url, storage)
+	syncer := NewSyncer(*url, archs, storage)
 
 	// first sync
 	err = syncer.StoreRepo()


### PR DESCRIPTION
Multi archs repositories have their packages metadata at the root level and we currently consider the full list of them for syncing.
This results in syncing also packages for archs which were not specified in the .yml file, when dealing with those repositories.