### PR TITLE
Add SHA512 hashing function

### DIFF
--- a/get/syncer.go
+++ b/get/syncer.go
@@ -64,6 +64,7 @@ var hashMap = map[string]crypto.Hash{
 	"sha":    crypto.SHA1,
 	"sha1":   crypto.SHA1,
 	"sha256": crypto.SHA256,
+	"sha512": crypto.SHA512,
 }
 
 const repomdPath = "repodata/repomd.xml"
@@ -459,6 +460,7 @@ func (r *Syncer) decide(location string, checksum XMLChecksum, checksumMap map[s
 		}
 		defer reader.Close()
 
+		log.Printf("Reading %s checksum\n", checksum.Type)
 		readChecksum, err := util.Checksum(reader, hashMap[checksum.Type])
 		if err != nil || readChecksum != checksum.Checksum {
 			return Download


### PR DESCRIPTION
Adds the SHA 512 hashing function to the available ones we use for verifying checksums.

It seems to be used by some of the newly downloaded repositories and it was missing in the map.

```
./minima sync -c minima.yaml 
Using config file: minima.yaml
2025/03/10 15:28:28 Processing repo: http://downloadcontent.opensuse.org/distribution/leap/15.6/repo/oss/
2025/03/10 15:28:28 First-time sync started
2025/03/10 15:28:28 Downloading repomd.xml...
2025/03/10 15:28:29 Downloading repomd.xml.asc...
2025/03/10 15:28:29 Downloading repomd.xml.key...
2025/03/10 15:28:29 repodata/72ade5926fe32d0008e6c2b8d931d47abbf209bd488d4156b3756b23734a47b6c63917f1940ee441fb363adb08daa46632d51cedfe9c4bea87a0f3fd9452e9db-primary.xml.gz
2025/03/10 15:28:29 Reading sha512 checksum
panic: crypto: requested hash function #0 is unavailable
```


Should fix the 1st issue in https://github.com/SUSE/spacewalk/issues/26645